### PR TITLE
Abstract typeclass for JSON Value generation

### DIFF
--- a/json-sop.cabal
+++ b/json-sop.cabal
@@ -28,6 +28,7 @@ library
                        lens-sop             >= 0.2  && < 0.3,
                        tagged               >= 0.7  && < 0.9,
                        aeson                >= 0.7  && < 1.2,
+                       constraints          >= 0.9  && < 0.10,
                        vector               >= 0.10 && < 0.13,
                        text                 >= 1.1  && < 1.3,
                        unordered-containers >= 0.2  && < 0.3,


### PR DESCRIPTION
Add gtoValue function allowing usage of user-supplied typeclass (not ToJSON) for Value
generation.

Refactor gtoJSON to use gtoValue specialized for ToJSON typeclass.