### PR TITLE
Make it build with recent GHC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swo
 *.hi
 *.o
+dist-newstyle

--- a/json-sop.cabal
+++ b/json-sop.cabal
@@ -27,7 +27,7 @@ library
                        generics-sop         >= 0.2.3 && < 0.6,
                        lens-sop             >= 0.2   && < 0.3,
                        tagged               >= 0.7   && < 0.9,
-                       aeson                >= 0.7   && < 1.5,
+                       aeson                >= 0.7   && < 1.6,
                        vector               >= 0.10  && < 0.13,
                        text                 >= 1.1   && < 1.3,
                        unordered-containers >= 0.2   && < 0.3,
@@ -54,7 +54,7 @@ library
                        DataKinds
                        FunctionalDependencies
                        CPP
-  if impl (ghc >= 7.8)
+  if impl (ghc >= 7.8) && impl (ghc < 8.2)
     default-extensions:  AutoDeriveTypeable
   other-extensions:    OverloadedStrings
                        PolyKinds

--- a/src/Generics/SOP/Util/PartialResult.hs
+++ b/src/Generics/SOP/Util/PartialResult.hs
@@ -37,11 +37,18 @@ instance Functor f => Functor (Partial f) where
 
 instance Functor f => Monad (Partial f) where
   return = PZero
+#if !MIN_VERSION_base(4,13,0)
   fail   = Fail . return
+#endif
 
   Fail e   >>= _ = Fail e
   PZero a  >>= f = f a
   PSucc fa >>= f = PSucc (fmap (>>= f) fa)
+
+#if MIN_VERSION_base(4,13,0)
+instance Functor f => MonadFail (Partial f) where
+  fail = Fail . return
+#endif
 
 instance (MonadPlus f, Functor f) => MonadPlus (Partial f) where
   mzero = Fail []
@@ -72,5 +79,3 @@ runPartial failWith = go
     go (PZero a)  = return a
     go (PSucc fa) = fa >>= go
     go (Fail  es) = failWith es
-
-


### PR DESCRIPTION
From `ghc` 8.8 (`base` 4.13) `fail`is no longer part of `Monad` but instead of `MonadFail`. 

This also relaxes some bounds.