### PR TITLE
Support `vector-0.13`

### DIFF
--- a/json-sop.cabal
+++ b/json-sop.cabal
@@ -28,7 +28,7 @@ library
                        lens-sop             >= 0.2   && < 0.3,
                        tagged               >= 0.7   && < 0.9,
                        aeson                >= 1.4   && < 2.2,
-                       vector               >= 0.10  && < 0.13,
+                       vector               >= 0.10  && < 0.14,
                        text                 >= 1.1   && < 1.3,
                        unordered-containers >= 0.2   && < 0.3,
                        time                 >= 1.4   && < 1.12,


### PR DESCRIPTION
Confirmed to build with `allow-newer: vector`