### PR TITLE
Build with `base-4.18`/GHC 9.6

### DIFF
--- a/json-sop.cabal
+++ b/json-sop.cabal
@@ -23,7 +23,7 @@ library
   exposed-modules:     Generics.SOP.JSON
                        Generics.SOP.JSON.Model
   other-modules:       Generics.SOP.Util.PartialResult
-  build-depends:       base                 >= 4.11  && < 4.18,
+  build-depends:       base                 >= 4.11  && < 4.19,
                        generics-sop         >= 0.2.3 && < 0.6,
 
                        -- lens-sop changed API in 0.3


### PR DESCRIPTION
Confirmed to build with `allow-newer`.